### PR TITLE
Comment xor_str() and xor_wstr() functions since they are not used

### DIFF
--- a/src/obfuscation.c
+++ b/src/obfuscation.c
@@ -1,17 +1,15 @@
 #include "obfuscation.h"
 
-#include <stdio.h>
-#include <wchar.h>
 /**
  * XOR the given string pointer by xoring each char with 42
  * @param str : the string to obfuscate/deobfuscate by xoring each character
  * @param size : size of given string
  */
-void xor_str(char *str, int size) {
+/*void xor_str(char *str, int size) {
   while (size-- > 0) {
     *str++ ^= 42;
   }
-}
+}*/
 
 /**
  * XOR the given wide string pointer by xoring each wide char with 42
@@ -19,8 +17,8 @@ void xor_str(char *str, int size) {
  * character
  * @param size : size of given string
  */
-void xor_wstr(wchar_t *wstr, int size) {
+/*void xor_wstr(wchar_t *wstr, int size) {
   while (size-- > 0) {
     *wstr++ ^= 42;
   }
-}
+}*/


### PR DESCRIPTION
I have commented the xor_str() and xor_wstr() functions in the obfuscation.c file since we are not using them now.
I have not removed the .c file to make the compilation step easier.